### PR TITLE
Add missing browserify-shim dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "angular": "global:angular"
   },
   "dependencies": {
+    "browserify-shim": "~3.8.3",
     "lodash": "~3.2.0",
     "q": "~1.0.1"
   },


### PR DESCRIPTION
Without this, bundling via browserify fails with:

```
Error: Cannot find module 'browserify-shim' from '/src/node_modules/pojoviz'
```